### PR TITLE
Expand the `Until` protocol to allow for more complex stopping conditions.

### DIFF
--- a/mule/__init__.py
+++ b/mule/__init__.py
@@ -1,4 +1,4 @@
 from ._attempts import attempting
-from ._until import Until, AttemptsExhausted
+from ._until import Until, attempts_exhausted
 
-__all__ = ["attempting", "Until", "AttemptsExhausted"]
+__all__ = ["attempting", "Until", "attempts_exhausted"]

--- a/mule/_until.py
+++ b/mule/_until.py
@@ -101,7 +101,7 @@ class CompositeUntilAny(Until):
 
 def attempts_exhausted(max_attempts: int) -> Until:
     """
-    A convenience function that returns an Until implementation keeps attempting if there is an exception,
-    but stops after a fixed number of attempts.
+    A convenience function that returns an Until implementation that stops attempts if
+    no exception is raised or the provided number of attempts is reached.
     """
     return AttemptsExhausted(max_attempts) | NoException()

--- a/mule/_until.py
+++ b/mule/_until.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from typing import Protocol
+import abc
 
 from mule._attempts import AttemptContext
 
 
-class Until(Protocol):
+class Until(abc.ABC):
     """
     A protocol that defines a stopping condition for an attempting generator.
     """
 
+    @abc.abstractmethod
     def is_condition_met(self, context: AttemptContext | None) -> bool:
         """
         Checks if execution should stop.
@@ -22,10 +23,41 @@ class Until(Protocol):
         """
         ...  # pragma: no cover
 
+    def __and__(self, other: Until) -> Until:
+        return CompositeUntilAll(self, other)
+
+    def __or__(self, other: Until) -> Until:
+        return CompositeUntilAny(self, other)
+
+
+class NoException(Until):
+    """
+    An Until implementation that stops if no exception is raised in the attempt context.
+    """
+
+    def is_condition_met(self, context: AttemptContext | None) -> bool:
+        if context is None:
+            return False
+        return context.exception is None
+
+
+class ExceptionMatches(Until):
+    """
+    An Until implementation that stops if the exception matches the given type.
+    """
+
+    def __init__(self, exception_type: type[BaseException]):
+        self.exception_type = exception_type
+
+    def is_condition_met(self, context: AttemptContext | None) -> bool:
+        if context is None:
+            return False
+        return isinstance(context.exception, self.exception_type)
+
 
 class AttemptsExhausted(Until):
     """
-    A Until implementation that stops after a fixed number of attempts.
+    An Until implementation that stops after a fixed number of attempts.
 
     Attributes:
         max_attempts: The maximum number of attempts. Execution will stop after
@@ -40,6 +72,36 @@ class AttemptsExhausted(Until):
     def is_condition_met(self, context: AttemptContext | None) -> bool:
         if context is None:
             return False
-        if context and context.exception is None:
-            return True
         return context.attempt >= self.max_attempts
+
+
+class CompositeUntilAll(Until):
+    """
+    An Until implementation that stops if all of the given Until instances are met.
+    """
+
+    def __init__(self, *until: Until):
+        self.until: tuple[Until, ...] = until
+
+    def is_condition_met(self, context: AttemptContext | None) -> bool:
+        return all(until.is_condition_met(context) for until in self.until)
+
+
+class CompositeUntilAny(Until):
+    """
+    An Until implementation that stops if any of the given Until instances are met.
+    """
+
+    def __init__(self, *until: Until):
+        self.until: tuple[Until, ...] = until
+
+    def is_condition_met(self, context: AttemptContext | None) -> bool:
+        return any(until.is_condition_met(context) for until in self.until)
+
+
+def attempts_exhausted(max_attempts: int) -> Until:
+    """
+    A convenience function that returns an Until implementation keeps attempting if there is an exception,
+    but stops after a fixed number of attempts.
+    """
+    return AttemptsExhausted(max_attempts) | NoException()

--- a/tests/test_attempting.py
+++ b/tests/test_attempting.py
@@ -1,13 +1,13 @@
 import pytest
 
-from mule import attempting, AttemptsExhausted
+from mule import attempting, attempts_exhausted
 
 
 class TestAttempting:
     def test_retry_context_with_eventual_success(self):
         attempts = 0
         result = None
-        for attempt in attempting(until=AttemptsExhausted(3)):
+        for attempt in attempting(until=attempts_exhausted(3)):
             with attempt:
                 attempts += 1
                 if attempts < 2:
@@ -21,7 +21,7 @@ class TestAttempting:
     def test_retry_context_with_failure(self):
         attempts = 0
         with pytest.raises(Exception):
-            for attempt in attempting(until=AttemptsExhausted(3)):
+            for attempt in attempting(until=attempts_exhausted(3)):
                 with attempt:
                     attempts += 1
                     raise Exception("Test exception")

--- a/tests/test_until.py
+++ b/tests/test_until.py
@@ -1,6 +1,12 @@
 import pytest
 
-from mule import AttemptsExhausted
+from mule._until import (
+    CompositeUntilAny,
+    AttemptsExhausted,
+    ExceptionMatches,
+    NoException,
+    CompositeUntilAll,
+)
 from mule._attempts import AttemptContext
 
 
@@ -27,3 +33,170 @@ class TestAttemptsExhausted:
 
         with pytest.raises(ValueError):
             AttemptsExhausted(-1)
+
+
+class TestNoException:
+    def test_no_exception(self):
+        until = NoException()
+        assert until.is_condition_met(None) is False
+
+        context = AttemptContext(attempt=1)
+        context.exception = RuntimeError()
+        assert until.is_condition_met(context) is False
+
+
+class TestExceptionMatches:
+    def test_exception_matches(self):
+        until = ExceptionMatches(RuntimeError)
+        assert until.is_condition_met(None) is False
+
+        context = AttemptContext(attempt=1)
+        context.exception = RuntimeError()
+        assert until.is_condition_met(context) is True
+
+
+class TestCompositeUntilAll:
+    def test_all_conditions_met(self):
+        context = AttemptContext(attempt=3)
+        context.exception = RuntimeError()
+        until = CompositeUntilAll(AttemptsExhausted(3), NoException())
+        assert until.is_condition_met(context) is False  # NoException not met
+        context.exception = None
+        assert until.is_condition_met(context) is True  # Both met
+
+    def test_not_all_conditions_met(self):
+        context = AttemptContext(attempt=2)
+        context.exception = RuntimeError()
+        until = CompositeUntilAll(AttemptsExhausted(3), NoException())
+        assert until.is_condition_met(context) is False
+
+    def test_creation_via_and(self):
+        # A bit nonsensical, but we'll test it anyway.
+        until = AttemptsExhausted(3) & NoException()
+        assert isinstance(until, CompositeUntilAll)
+
+        # No exception, but the max attempts is not reached, so it should be false.
+        context = AttemptContext(attempt=1)
+        assert until.is_condition_met(context) is False
+
+        # Max attempts is reached, but there is an exception, so it should be false.
+        context = AttemptContext(attempt=3)
+        context.exception = RuntimeError()
+        assert until.is_condition_met(context) is False
+
+        # No exception and the max attempts is reached, so it should be true.
+        context = AttemptContext(attempt=3)
+        context.exception = None
+        assert until.is_condition_met(context) is True
+
+
+class TestCompositeUntilAny:
+    def test_any_condition_met(self):
+        context = AttemptContext(attempt=3)
+        context.exception = RuntimeError()
+        until = CompositeUntilAny(AttemptsExhausted(3), NoException())
+        assert until.is_condition_met(context) is True  # AttemptsExhausted met
+        context = AttemptContext(attempt=1)
+        context.exception = None
+        assert until.is_condition_met(context) is True  # NoException met
+
+    def test_no_conditions_met(self):
+        context = AttemptContext(attempt=1)
+        context.exception = RuntimeError()
+        until = CompositeUntilAny(AttemptsExhausted(3), NoException())
+        assert until.is_condition_met(context) is False
+
+    def test_creation_via_or(self):
+        until = AttemptsExhausted(3) | NoException()
+        assert isinstance(until, CompositeUntilAny)
+
+        # No exception, so it should be true.
+        context = AttemptContext(attempt=1)
+        assert until.is_condition_met(context) is True
+
+        # Max attempts is reached, so it should be true.
+        context = AttemptContext(attempt=3)
+        context.exception = RuntimeError()
+        assert until.is_condition_met(context) is True
+
+
+class TestComplexUntilCombinations:
+    def test_nested_and_or(self):
+        # (AttemptsExhausted(3) & NoException()) | ExceptionMatches(ValueError)
+        until = (AttemptsExhausted(3) & NoException()) | ExceptionMatches(ValueError)
+        context = AttemptContext(attempt=1)
+        context.exception = RuntimeError()
+        assert (
+            until.is_condition_met(context) is False
+        )  # Neither AND nor ExceptionMatches(ValueError) met
+
+        context = AttemptContext(attempt=3)
+        context.exception = RuntimeError()
+        assert (
+            until.is_condition_met(context) is False
+        )  # AND not met, ExceptionMatches(ValueError) not met
+
+        context.exception = None
+        assert until.is_condition_met(context) is True  # AND met
+
+        context = AttemptContext(attempt=1)
+        context.exception = ValueError()
+        assert (
+            until.is_condition_met(context) is True
+        )  # ExceptionMatches(ValueError) met
+
+    def test_nested_or_and(self):
+        # (AttemptsExhausted(3) | NoException()) & ExceptionMatches(ValueError)
+        until = (AttemptsExhausted(3) | NoException()) & ExceptionMatches(ValueError)
+        context = AttemptContext(attempt=1)
+        context.exception = RuntimeError()
+        assert (
+            until.is_condition_met(context) is False
+        )  # ExceptionMatches(ValueError) not met
+
+        context.exception = ValueError()
+        assert (
+            until.is_condition_met(context) is False
+        )  # ExceptionMatches(ValueError) met, NoException not met
+
+        context = AttemptContext(attempt=3)
+        context.exception = ValueError()
+        assert (
+            until.is_condition_met(context) is True
+        )  # AttemptsExhausted(3) met, ExceptionMatches(ValueError) met
+
+    def test_multiple_and_or(self):
+        # AttemptsExhausted(3) & NoException() & ExceptionMatches(ValueError)
+        until = AttemptsExhausted(3) & NoException() & ExceptionMatches(ValueError)
+        context = AttemptContext(attempt=3)
+        context.exception = ValueError()
+        assert until.is_condition_met(context) is False  # NoException not met
+
+        context.exception = None
+        assert (
+            until.is_condition_met(context) is False
+        )  # ExceptionMatches(ValueError) not met
+
+        # Only if all are met
+        # This is not possible, but test for completeness
+
+    def test_multiple_or(self):
+        # AttemptsExhausted(3) | NoException() | ExceptionMatches(ValueError)
+        until = AttemptsExhausted(3) | NoException() | ExceptionMatches(ValueError)
+        context = AttemptContext(attempt=1)
+        context.exception = RuntimeError()
+        assert until.is_condition_met(context) is False
+
+        context = AttemptContext(attempt=3)
+        context.exception = RuntimeError()
+        assert until.is_condition_met(context) is True  # AttemptsExhausted(3) met
+
+        context = AttemptContext(attempt=1)
+        context.exception = None
+        assert until.is_condition_met(context) is True  # NoException met
+
+        context = AttemptContext(attempt=1)
+        context.exception = ValueError()
+        assert (
+            until.is_condition_met(context) is True
+        )  # ExceptionMatches(ValueError) met


### PR DESCRIPTION
This allows for more complex stopping conditions, such as:

- Stopping if no exception is raised
- Stopping if the exception matches a given type
- Combining multiple Until instances with `&` and `|`
