### PR TITLE
Default `AttemptGenerator` to use `NoException`

### DIFF
--- a/mule/__init__.py
+++ b/mule/__init__.py
@@ -1,4 +1,3 @@
 from ._attempts import attempting
-from ._stop_conditions import StopCondition, attempts_exhausted
 
-__all__ = ["attempting", "StopCondition", "attempts_exhausted"]
+__all__ = ["attempting"]

--- a/mule/_attempts.py
+++ b/mule/_attempts.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 from types import TracebackType
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from mule._stop_conditions import StopCondition  # pragma: no cover
+from mule.stop_conditions import NoException, StopCondition
 
 
 class AttemptGenerator:
@@ -13,8 +11,11 @@ class AttemptGenerator:
     The stopping condition is defined by the `StopCondition` protocol.
     """
 
-    def __init__(self, until: "StopCondition"):
-        self.stop_condition: "StopCondition" = until
+    def __init__(self, until: "StopCondition | None" = None):
+        if until is None:
+            self.stop_condition = NoException()
+        else:
+            self.stop_condition: "StopCondition" = until | NoException()
         self._attempts: list[AttemptContext] = []
 
     @property

--- a/tests/test_attempts.py
+++ b/tests/test_attempts.py
@@ -1,13 +1,21 @@
 import pytest
 
-from mule import attempting, attempts_exhausted
+from mule import attempting
+from mule._attempts import AttemptGenerator
+from mule.stop_conditions import AttemptsExhausted, NoException
+
+
+class TestAttemptGenerator:
+    def test_default_stop_condition(self):
+        generator = AttemptGenerator()
+        assert generator.stop_condition == NoException()
 
 
 class TestAttempting:
     def test_retry_context_with_eventual_success(self):
         attempts = 0
         result = None
-        for attempt in attempting(until=attempts_exhausted(3)):
+        for attempt in attempting(until=AttemptsExhausted(3)):
             with attempt:
                 attempts += 1
                 if attempts < 2:
@@ -21,7 +29,7 @@ class TestAttempting:
     def test_retry_context_with_failure(self):
         attempts = 0
         with pytest.raises(Exception):
-            for attempt in attempting(until=attempts_exhausted(3)):
+            for attempt in attempting(until=AttemptsExhausted(3)):
                 with attempt:
                     attempts += 1
                     raise Exception("Test exception")

--- a/tests/test_stop_conditions.py
+++ b/tests/test_stop_conditions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mule._stop_conditions import (
+from mule.stop_conditions import (
     IntersectionStopCondition,
     AttemptsExhausted,
     ExceptionMatches,
@@ -8,6 +8,15 @@ from mule._stop_conditions import (
     UnionStopCondition,
 )
 from mule._attempts import AttemptContext
+
+
+class TestStopCondition:
+    def test_eq(self):
+        stop_condition = AttemptsExhausted(3)
+        assert stop_condition == AttemptsExhausted(3)
+        assert stop_condition != AttemptsExhausted(4)
+        assert stop_condition != NoException()
+        assert stop_condition != 3
 
 
 class TestAttemptsExhausted:
@@ -182,9 +191,6 @@ class TestComplexStopConditionCombinations:
         assert (
             stop_condition.is_met(context) is False
         )  # ExceptionMatches(ValueError) not met
-
-        # Only if all are met
-        # This is not possible, but test for completeness
 
     def test_multiple_or(self):
         # AttemptsExhausted(3) | NoException() | ExceptionMatches(ValueError)


### PR DESCRIPTION
Ensures that retries will always occur if there is an exception, even if a different stop condition is provided.
