### PR TITLE
Add `@retry` decorator

### DIFF
--- a/mule/__init__.py
+++ b/mule/__init__.py
@@ -1,3 +1,5 @@
 from ._attempts import attempting
+from ._retry import retry
 
-__all__ = ["attempting"]
+
+__all__ = ["attempting", "retry"]

--- a/mule/_retry.py
+++ b/mule/_retry.py
@@ -62,7 +62,7 @@ def retry(
     Example:
         Retry a function until 3 attempts have been made.
         ```python
-        from mule.retry import retry
+        from mule import retry
         from mule.stop_conditions import AttemptsExhausted
 
         @retry(until=AttemptsExhausted(3))

--- a/mule/_retry.py
+++ b/mule/_retry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial, update_wrapper
 from typing import Callable, Generic, TypeVar, cast, overload
 from typing_extensions import ParamSpec

--- a/mule/_retry.py
+++ b/mule/_retry.py
@@ -1,0 +1,80 @@
+from functools import partial, update_wrapper
+from typing import Callable, Generic, TypeVar, cast, overload
+from typing_extensions import ParamSpec
+
+from mule.stop_conditions import StopCondition
+from mule._attempts import AttemptGenerator
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+class Retriable(Generic[P, R]):
+    """
+    A callable that retries a function until a stop condition is met.
+
+    In most cases, you should use the `@retry` decorator instead of instantiating this class directly.
+
+    Args:
+        __fn: The function to retry on failure.
+        until: A `StopCondition` that determines when to stop retrying the provided function.
+    """
+
+    def __init__(self, __fn: Callable[P, R], *, until: StopCondition | None = None):
+        self.fn = __fn
+        update_wrapper(self, __fn)
+        self.attempting: AttemptGenerator = AttemptGenerator(until=until)
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        for attempt in self.attempting:
+            with attempt:
+                return self.fn(*args, **kwargs)
+
+        raise RuntimeError(
+            "Failed to make a single attempt with the given stop condition"
+        )
+
+
+@overload
+def retry(
+    __fn: None = None, *, until: StopCondition | None = None
+) -> Callable[[Callable[P, R]], Retriable[P, R]]: ...
+
+
+@overload
+def retry(
+    __fn: Callable[P, R], *, until: StopCondition | None = None
+) -> Retriable[P, R]: ...
+
+
+def retry(
+    __fn: Callable[P, R] | None = None, *, until: StopCondition | None = None
+) -> Retriable[P, R] | Callable[[Callable[P, R]], Retriable[P, R]]:
+    """
+    A function decorator that retries a function until a stop condition is met.
+
+    Args:
+        until: A `StopCondition` that determines when to stop retrying the provided function.
+
+    Example:
+        Retry a function until 3 attempts have been made.
+        ```python
+        from mule.retry import retry
+        from mule.stop_conditions import AttemptsExhausted
+
+        @retry(until=AttemptsExhausted(3))
+        def f(x: int) -> int:
+            return x * 3
+        ```
+    """
+    if __fn is None:
+        return cast(
+            Callable[
+                [Callable[P, R]],
+                Retriable[P, R],
+            ],
+            partial(retry, until=until),
+        )
+    else:
+        return Retriable(__fn, until=until)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ version = "0.1.0"
 description = "Add a stubborn streak to your code."
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = []
+dependencies = [
+    "typing-extensions>=4.13.2",
+]
 
 [dependency-groups]
 dev = [

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from mule._attempts import AttemptContext
 from mule._retry import retry, Retriable

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,95 @@
+import pytest
+from mule._attempts import AttemptContext
+from mule._retry import retry, Retriable
+from mule.stop_conditions import AttemptsExhausted, StopCondition
+
+
+def always_succeeds(x: int) -> int:
+    return x * 2
+
+
+def sometimes_fails(x: int) -> int:
+    """
+    Sometimes fails with a ValueError.
+    """
+    if x < 0:
+        raise ValueError("Negative!")
+    return x
+
+
+class TestRetriable:
+    def test_retriable_success(self):
+        r = Retriable(always_succeeds, until=AttemptsExhausted(3))
+        assert r(5) == 10
+
+    def test_retriable_failure(self):
+        r = Retriable(
+            lambda: (_ for _ in ()).throw(ValueError()), until=AttemptsExhausted(2)
+        )
+        with pytest.raises(ValueError):
+            r()
+
+    def test_retriable_eventual_success(self):
+        attempts = 0
+
+        def fn(x: int) -> int:
+            nonlocal attempts
+            attempts += 1
+            if attempts < 2:
+                raise Exception("fail")
+            return x
+
+        r = Retriable(fn, until=AttemptsExhausted(3))
+        assert r(42) == 42
+        assert attempts == 2
+
+    def test_retriable_wraps_callable(self):
+        r = Retriable(sometimes_fails, until=AttemptsExhausted(3))
+        assert getattr(r, "__wrapped__", None) is sometimes_fails
+        assert getattr(r, "__name__", None) == "sometimes_fails"
+        assert getattr(r, "__doc__", None) == sometimes_fails.__doc__
+
+
+class TestRetryDecorator:
+    def test_retry_decorator_success(self):
+        @retry(until=AttemptsExhausted(2))
+        def f(x: int) -> int:
+            return x + 1
+
+        assert f(2) == 3
+
+    def test_retry_decorator_eventual_success(self):
+        attempts = 0
+
+        @retry(until=AttemptsExhausted(3))
+        def f(x: int) -> int:
+            nonlocal attempts
+            attempts += 1
+            if attempts < 2:
+                raise Exception("fail")
+            return x
+
+        assert f(7) == 7
+        assert attempts == 2
+
+    def test_retry_decorator_no_until(self):
+        @retry
+        def f(x: int) -> int:
+            return x * 3
+
+        assert f(3) == 9
+
+    def test_retry_with_invalid_stop_condition(self):
+        class NeverAttempt(StopCondition):
+            def is_met(self, context: AttemptContext | None) -> bool:
+                return True
+
+        @retry(until=NeverAttempt())
+        def f(x: int) -> int:
+            return x * 3
+
+        with pytest.raises(
+            RuntimeError,
+            match="Failed to make a single attempt with the given stop condition",
+        ):
+            f(3)

--- a/uv.lock
+++ b/uv.lock
@@ -147,6 +147,9 @@ wheels = [
 name = "mule"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "typing-extensions" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -159,6 +162,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "typing-extensions", specifier = ">=4.13.2" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Adds a `@retry` decorator that wraps the provided function in a `Retriable` class. The `Retriable` class is a callable that retries the provided function until a stop condition is met.
