### PR TITLE
Add support for inverting stop conditions

### DIFF
--- a/mule/stop_conditions.py
+++ b/mule/stop_conditions.py
@@ -36,6 +36,9 @@ class StopCondition(abc.ABC):
             return False
         return self.__dict__ == other.__dict__
 
+    def __invert__(self) -> StopCondition:
+        return InvertedStopCondition(self)
+
 
 class NoException(StopCondition):
     """
@@ -104,6 +107,23 @@ class UnionStopCondition(StopCondition):
 
     def is_met(self, context: "AttemptContext | None") -> bool:
         return any(condition.is_met(context) for condition in self.conditions)
+
+
+class InvertedStopCondition(StopCondition):
+    """
+    A StopCondition implementation that inverts the given StopCondition.
+    """
+
+    def __init__(self, condition: StopCondition):
+        self.condition = condition
+
+    def is_met(self, context: "AttemptContext | None") -> bool:
+        if context is None:
+            return False
+        return not self.condition.is_met(context)
+
+    def __invert__(self) -> StopCondition:
+        return self.condition
 
 
 __all__ = [

--- a/tests/test_stop_conditions.py
+++ b/tests/test_stop_conditions.py
@@ -214,3 +214,23 @@ class TestComplexStopConditionCombinations:
         assert (
             stop_condition.is_met(context) is True
         )  # ExceptionMatches(ValueError) met
+
+
+class TestInvertedStopCondition:
+    def test_inverted_stop_condition(self):
+        stop_condition = ~ExceptionMatches(RuntimeError)
+        assert stop_condition.is_met(None) is False
+
+        context = AttemptContext(attempt=1)
+        context.exception = RuntimeError()
+        assert stop_condition.is_met(context) is False
+
+        context = AttemptContext(attempt=1)
+        context.exception = ValueError()
+        assert stop_condition.is_met(context) is True
+
+    def test_double_inversion(self):
+        original_stop_condition = ExceptionMatches(RuntimeError)
+        inverted_stop_condition = ~original_stop_condition
+        assert ~inverted_stop_condition is original_stop_condition
+        assert ~original_stop_condition == inverted_stop_condition


### PR DESCRIPTION
Stop conditions can now be inverted using the `~` operator.

This is useful for creating stop conditions that are the negation of other stop conditions.

Example:
Create a stop condition that stops retrying if the exception is not a `RuntimeError`.
```python
from mule.stop_conditions import ExceptionMatches,

stop_condition = ~ExceptionMatches(RuntimeError)
```
