### PR TITLE
Add `WaitTimeProvider` protocol

### DIFF
--- a/.cursor/rules/style-and-linting.mdc
+++ b/.cursor/rules/style-and-linting.mdc
@@ -1,0 +1,23 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+- Follow Ruff and Ruff-format rules: All code must pass ruff and ruff-format as enforced by pre-commit.
+- Always run `ruff format` before committing. Do not manually override formatting decisions made by automated tools.
+- Docstrings: All public modules, classes, methods, and functions must have docstrings following the Google docstring style. Docstrings should include a summary, argument descriptions, return values, and exceptions raised (if any).
+- Example (Google style):
+    def add(a: int, b: int) -> int:
+        \"\"\"Add two integers.
+
+        Args:
+            a: The first integer.
+            b: The second integer.
+
+        Returns:
+            The sum of a and b.
+        \"\"\"
+- Line length: Max line length is 88 characters.
+- No unused imports or variables: Remove any code flagged by Ruff as unused.
+- Organize imports in the following order: standard library, third-party, local application imports.
+- All public functions and methods must include complete type hints for arguments and return values.

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,0 +1,15 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+- Use `pytest` for all tests: All test files should use pytest conventions (fixtures, parametrize, etc.).
+- Test file naming: All test files should be named test_*.py and placed in the tests/ directory.
+- Test function naming: All test functions should be prefixed with `test_` for pytest discovery.
+- Test coverage: When adding new features or fixing bugs, add or update tests to cover the changes.
+- Mocking: Use unittest.mock or pytest fixtures for mocking dependencies (see mock_sleep usage).
+- Use plain `assert` statements to leverage pytest's assertion introspection.
+- Use `pytest.mark.parametrize` for similar test cases.
+- Use `pytest` fixtures for setup and teardown logic.
+- All test functions and classes should have descriptive names and, where appropriate, docstrings explaining the test's purpose.
+- Tests should be isolated and deterministic; avoid reliance on global state or external resources.

--- a/.cursor/rules/typing.mdc
+++ b/.cursor/rules/typing.mdc
@@ -1,0 +1,9 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+- Use built-in types (`list`, `dict`, `set`) instead of `Dict`, `List`, and `Set` when type hinting.
+- Use `|` instead of `Union` for type unions.
+- Use `| None` instead of `Optional` for optional types.
+- Whenever using `|` for type hinting, add `from __future__ import annotations` at the top of the file to support Python 3.8 and 3.9.


### PR DESCRIPTION
Allows users to provide a callable that produces a wait time given the previous and next AttemptContext.

This is useful for implementing exponential backoff, for example.
```python
from mule import retry
from mule.stop_conditions import AttemptsExhausted

def exp_backoff(prev: AttemptContext | None, next: AttemptContext) -> int:
    return min(2 ** (next.attempt - 1), 60)

@retry(until=AttemptsExhausted(5), wait=exp_backoff)
def f(x: int) -> int:
    return x * 3
```
