### PR TITLE
Add hook decorators to `Retriable`

### DIFF
--- a/mule/_retry.py
+++ b/mule/_retry.py
@@ -87,7 +87,7 @@ class Retriable(Generic[P, R]):
 
         return _call()
 
-    def before_attempt(self, hook: AttemptHook) -> Retriable[P, R]:
+    def before_attempt(self, hook: AttemptHook) -> AttemptHook:
         """
         Add a hook that will be called before each attempt.
 
@@ -106,9 +106,9 @@ class Retriable(Generic[P, R]):
         ```
         """
         self.before_attempt_hooks.append(hook)
-        return self
+        return hook
 
-    def on_success(self, hook: AttemptHook) -> Retriable[P, R]:
+    def on_success(self, hook: AttemptHook) -> AttemptHook:
         """
         Add a hook that will be called when the wrapped function succeeds.
 
@@ -126,9 +126,9 @@ class Retriable(Generic[P, R]):
             print(f"Attempt {state.attempt} succeeded")
         """
         self.on_success_hooks.append(hook)
-        return self
+        return hook
 
-    def on_failure(self, hook: AttemptHook) -> Retriable[P, R]:
+    def on_failure(self, hook: AttemptHook) -> AttemptHook:
         """
         Add a hook that will be called when the wrapped function fails.
 
@@ -147,9 +147,9 @@ class Retriable(Generic[P, R]):
         ```
         """
         self.on_failure_hooks.append(hook)
-        return self
+        return hook
 
-    def before_wait(self, hook: AttemptHook) -> Retriable[P, R]:
+    def before_wait(self, hook: AttemptHook) -> AttemptHook:
         """
         Add a hook that will be called before each wait.
 
@@ -168,9 +168,9 @@ class Retriable(Generic[P, R]):
         ```
         """
         self.before_wait_hooks.append(hook)
-        return self
+        return hook
 
-    def after_wait(self, hook: AttemptHook) -> Retriable[P, R]:
+    def after_wait(self, hook: AttemptHook) -> AttemptHook:
         """
         Add a hook that will be called after each wait.
 
@@ -189,7 +189,7 @@ class Retriable(Generic[P, R]):
         ```
         """
         self.after_wait_hooks.append(hook)
-        return self
+        return hook
 
 
 @overload

--- a/mule/_retry.py
+++ b/mule/_retry.py
@@ -6,6 +6,7 @@ from inspect import iscoroutinefunction
 from typing import TYPE_CHECKING, Awaitable, Callable, Generic, TypeVar, cast, overload
 from typing_extensions import ParamSpec
 
+from mule._attempts.protocols import AttemptHook
 from mule.stop_conditions import StopCondition
 from mule._attempts import AttemptGenerator, AsyncAttemptGenerator, WaitTimeProvider
 
@@ -37,12 +38,25 @@ class Retriable(Generic[P, R]):
         update_wrapper(self, __fn)
         self.until = until
         self.wait = wait
+        self.before_attempt_hooks: list[AttemptHook] = []
+        self.on_success_hooks: list[AttemptHook] = []
+        self.on_failure_hooks: list[AttemptHook] = []
+        self.before_wait_hooks: list[AttemptHook] = []
+        self.after_wait_hooks: list[AttemptHook] = []
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
         if iscoroutinefunction(self.fn):
             return self._call_async(*args, **kwargs)  # pyright: ignore[reportReturnType]
 
-        for attempt in AttemptGenerator(until=self.until, wait=self.wait):
+        for attempt in AttemptGenerator(
+            until=self.until,
+            wait=self.wait,
+            before_attempt=self.before_attempt_hooks,
+            on_success=self.on_success_hooks,
+            on_failure=self.on_failure_hooks,
+            before_wait=self.before_wait_hooks,
+            after_wait=self.after_wait_hooks,
+        ):
             with attempt:
                 return self.fn(*args, **kwargs)
 
@@ -66,6 +80,110 @@ class Retriable(Generic[P, R]):
             )
 
         return _call()
+
+    def before_attempt(self, hook: AttemptHook) -> Retriable[P, R]:
+        """
+        Add a hook that will be called before each attempt.
+
+        Example:
+        ```python
+        from mule import retry
+        from mule.stop_conditions import AttemptsExhausted
+
+        @retry(until=AttemptsExhausted(3))
+        def f(x: int) -> int:
+            return x * 3
+
+        @f.before_attempt
+        def before_attempt(state: AttemptState):
+            print(f"Attempt {state.attempt} started")
+        ```
+        """
+        self.before_attempt_hooks.append(hook)
+        return self
+
+    def on_success(self, hook: AttemptHook) -> Retriable[P, R]:
+        """
+        Add a hook that will be called when the wrapped function succeeds.
+
+        Example:
+        ```python
+        from mule import retry
+        from mule.stop_conditions import AttemptsExhausted
+
+        @retry(until=AttemptsExhausted(3))
+        def f(x: int) -> int:
+            return x * 3
+
+        @f.on_success
+        def on_success(state: AttemptState):
+            print(f"Attempt {state.attempt} succeeded")
+        """
+        self.on_success_hooks.append(hook)
+        return self
+
+    def on_failure(self, hook: AttemptHook) -> Retriable[P, R]:
+        """
+        Add a hook that will be called when the wrapped function fails.
+
+        Example:
+        ```python
+        from mule import retry
+        from mule.stop_conditions import AttemptsExhausted
+
+        @retry(until=AttemptsExhausted(3))
+        def f(x: int) -> int:
+            raise RuntimeError()
+
+        @f.on_failure
+        def on_failure(state: AttemptState):
+            print(f"Attempt {state.attempt} failed")
+        ```
+        """
+        self.on_failure_hooks.append(hook)
+        return self
+
+    def before_wait(self, hook: AttemptHook) -> Retriable[P, R]:
+        """
+        Add a hook that will be called before each wait.
+
+        Example:
+        ```python
+        from mule import retry
+        from mule.stop_conditions import AttemptsExhausted
+
+        @retry(until=AttemptsExhausted(3), wait=5)
+        def f(x: int) -> int:
+            raise RuntimeError()
+
+        @f.before_wait
+        def before_wait(state: AttemptState):
+            print(f"Waiting before next attempt")
+        ```
+        """
+        self.before_wait_hooks.append(hook)
+        return self
+
+    def after_wait(self, hook: AttemptHook) -> Retriable[P, R]:
+        """
+        Add a hook that will be called after each wait.
+
+        Example:
+        ```python
+        from mule import retry
+        from mule.stop_conditions import AttemptsExhausted
+
+        @retry(until=AttemptsExhausted(3), wait=5)
+        def f(x: int) -> int:
+            raise RuntimeError()
+
+        @f.after_wait
+        def after_wait(state: AttemptState):
+            print(f"Finished waiting")
+        ```
+        """
+        self.after_wait_hooks.append(hook)
+        return self
 
 
 @overload

--- a/mule/_retry.py
+++ b/mule/_retry.py
@@ -67,7 +67,13 @@ class Retriable(Generic[P, R]):
     def _call_async(self, *args: P.args, **kwargs: P.kwargs) -> Awaitable[R]:
         async def _call() -> R:
             async for attempt in AsyncAttemptGenerator(
-                until=self.until, wait=self.wait
+                until=self.until,
+                wait=self.wait,
+                before_attempt=self.before_attempt_hooks,
+                on_success=self.on_success_hooks,
+                on_failure=self.on_failure_hooks,
+                before_wait=self.before_wait_hooks,
+                after_wait=self.after_wait_hooks,
             ):
                 async with attempt:
                     if TYPE_CHECKING:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+
+@pytest.fixture
+def mock_sleep(monkeypatch: pytest.MonkeyPatch):
+    """
+    Mocks the `time.sleep` function.
+    """
+    mock_sleep = MagicMock()
+    monkeypatch.setattr("time.sleep", mock_sleep)
+    return mock_sleep
+
+
+@pytest.fixture
+def mock_async_sleep(monkeypatch: pytest.MonkeyPatch):
+    """
+    Mocks the `asyncio.sleep` function.
+    """
+    mock_sleep = AsyncMock()
+    monkeypatch.setattr("asyncio.sleep", mock_sleep)
+    return mock_sleep

--- a/tests/test_attempts.py
+++ b/tests/test_attempts.py
@@ -10,20 +10,6 @@ from mule._attempts.dataclasses import AttemptState
 from mule.stop_conditions import AttemptsExhausted, NoException
 
 
-@pytest.fixture
-def mock_sleep(monkeypatch: pytest.MonkeyPatch):
-    mock_sleep = MagicMock()
-    monkeypatch.setattr("time.sleep", mock_sleep)
-    return mock_sleep
-
-
-@pytest.fixture
-def mock_async_sleep(monkeypatch: pytest.MonkeyPatch):
-    mock_sleep = AsyncMock()
-    monkeypatch.setattr("asyncio.sleep", mock_sleep)
-    return mock_sleep
-
-
 class TestAttemptGenerator:
     def test_default_stop_condition(self):
         generator = AttemptGenerator()


### PR DESCRIPTION
Synaptic sugar for defining attempt lifecycle hooks:
```python
from mule import retry
from mule.stop_conditions import AttemptsExhausted

@retry(until=AttemptsExhausted(3))
def f(x: int) -> int:
    return x * 3

@f.before_attempt
def before_attempt(state: AttemptState):
    print(f"Attempt {state.attempt} started")
```
