### PR TITLE
Add support for async hooks to the retry decorator

### DIFF
--- a/mule/_attempts/aio.py
+++ b/mule/_attempts/aio.py
@@ -6,7 +6,7 @@ import logging
 from types import TracebackType
 from typing import TYPE_CHECKING, Literal, Sequence, cast
 
-from mule._attempts.protocols import AsyncAttemptHook, AttemptHook
+from mule._attempts.protocols import AsyncAttemptHook, AttemptHook, HookType
 from mule.stop_conditions import NoException, StopCondition
 from .dataclasses import AttemptState
 
@@ -14,11 +14,6 @@ if TYPE_CHECKING:
     from .protocols import WaitTimeProvider  # pragma: no cover
 
 _logger = logging.getLogger("mule")
-
-
-HookType = Literal[
-    "before_attempt", "on_success", "on_failure", "before_wait", "after_wait"
-]
 
 
 class AsyncAttemptGenerator:

--- a/mule/_attempts/protocols.py
+++ b/mule/_attempts/protocols.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 from typing_extensions import Protocol
 
 if TYPE_CHECKING:
     from .dataclasses import AttemptState  # pragma: no cover
+
+HookType = Literal[
+    "before_attempt", "on_success", "on_failure", "before_wait", "after_wait"
+]
 
 
 class WaitTimeProvider(Protocol):

--- a/mule/_retry.py
+++ b/mule/_retry.py
@@ -6,13 +6,14 @@ from inspect import iscoroutinefunction
 from typing import TYPE_CHECKING, Awaitable, Callable, Generic, TypeVar, cast, overload
 from typing_extensions import ParamSpec
 
-from mule._attempts.protocols import AttemptHook
+from mule._attempts.protocols import AsyncAttemptHook, AttemptHook
 from mule.stop_conditions import StopCondition
 from mule._attempts import AttemptGenerator, AsyncAttemptGenerator, WaitTimeProvider
 
 
 P = ParamSpec("P")
 R = TypeVar("R")
+H = TypeVar("H", bound=AttemptHook | AsyncAttemptHook)
 
 
 class Retriable(Generic[P, R]):
@@ -38,11 +39,11 @@ class Retriable(Generic[P, R]):
         update_wrapper(self, __fn)
         self.until = until
         self.wait = wait
-        self.before_attempt_hooks: list[AttemptHook] = []
-        self.on_success_hooks: list[AttemptHook] = []
-        self.on_failure_hooks: list[AttemptHook] = []
-        self.before_wait_hooks: list[AttemptHook] = []
-        self.after_wait_hooks: list[AttemptHook] = []
+        self.before_attempt_hooks: list[AttemptHook | AsyncAttemptHook] = []
+        self.on_success_hooks: list[AttemptHook | AsyncAttemptHook] = []
+        self.on_failure_hooks: list[AttemptHook | AsyncAttemptHook] = []
+        self.before_wait_hooks: list[AttemptHook | AsyncAttemptHook] = []
+        self.after_wait_hooks: list[AttemptHook | AsyncAttemptHook] = []
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
         if iscoroutinefunction(self.fn):
@@ -87,7 +88,7 @@ class Retriable(Generic[P, R]):
 
         return _call()
 
-    def before_attempt(self, hook: AttemptHook) -> AttemptHook:
+    def before_attempt(self, hook: H) -> H:
         """
         Add a hook that will be called before each attempt.
 
@@ -108,7 +109,7 @@ class Retriable(Generic[P, R]):
         self.before_attempt_hooks.append(hook)
         return hook
 
-    def on_success(self, hook: AttemptHook) -> AttemptHook:
+    def on_success(self, hook: H) -> H:
         """
         Add a hook that will be called when the wrapped function succeeds.
 
@@ -128,7 +129,7 @@ class Retriable(Generic[P, R]):
         self.on_success_hooks.append(hook)
         return hook
 
-    def on_failure(self, hook: AttemptHook) -> AttemptHook:
+    def on_failure(self, hook: H) -> H:
         """
         Add a hook that will be called when the wrapped function fails.
 
@@ -149,7 +150,7 @@ class Retriable(Generic[P, R]):
         self.on_failure_hooks.append(hook)
         return hook
 
-    def before_wait(self, hook: AttemptHook) -> AttemptHook:
+    def before_wait(self, hook: H) -> H:
         """
         Add a hook that will be called before each wait.
 
@@ -170,7 +171,7 @@ class Retriable(Generic[P, R]):
         self.before_wait_hooks.append(hook)
         return hook
 
-    def after_wait(self, hook: AttemptHook) -> AttemptHook:
+    def after_wait(self, hook: H) -> H:
         """
         Add a hook that will be called after each wait.
 

--- a/mule/_retry.py
+++ b/mule/_retry.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import datetime
 from functools import partial, update_wrapper
 from inspect import iscoroutinefunction
-from typing import TYPE_CHECKING, Awaitable, Callable, Generic, TypeVar, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Awaitable,
+    Callable,
+    Generic,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 from typing_extensions import ParamSpec
 
 from mule._attempts.protocols import AsyncAttemptHook, AttemptHook
@@ -13,7 +22,7 @@ from mule._attempts import AttemptGenerator, AsyncAttemptGenerator, WaitTimeProv
 
 P = ParamSpec("P")
 R = TypeVar("R")
-H = TypeVar("H", bound=AttemptHook | AsyncAttemptHook)
+H = TypeVar("H", bound=Union[AttemptHook, AsyncAttemptHook])
 
 
 class Retriable(Generic[P, R]):

--- a/tests/test_attempts.py
+++ b/tests/test_attempts.py
@@ -163,8 +163,12 @@ class TestAttemptingHooks:
             attempts = 0
             spy = MagicMock()
             async_spy = AsyncMock()
+
+            async def async_hook_wrapper(state: AttemptState) -> None:
+                await async_spy(state=state)
+
             for attempt in attempting(
-                until=AttemptsExhausted(3), before_attempt=[spy, async_spy]
+                until=AttemptsExhausted(3), before_attempt=[spy, async_hook_wrapper]
             ):
                 with attempt:
                     attempts += 1
@@ -189,8 +193,12 @@ class TestAttemptingHooks:
             attempts = 0
             spy = MagicMock()
             async_spy = AsyncMock()
+
+            async def async_hook_wrapper(state: AttemptState) -> None:
+                await async_spy(state=state)
+
             for attempt in attempting(
-                until=AttemptsExhausted(3), on_success=[spy, async_spy]
+                until=AttemptsExhausted(3), on_success=[spy, async_hook_wrapper]
             ):
                 with attempt:
                     attempts += 1
@@ -207,10 +215,14 @@ class TestAttemptingHooks:
             attempts = 0
             spy = MagicMock()
             async_spy = AsyncMock()
+
+            async def async_hook_wrapper(state: AttemptState) -> None:
+                await async_spy(state=state)
+
             exception = Exception("Test exception")
             with pytest.raises(Exception):
                 for attempt in attempting(
-                    until=AttemptsExhausted(3), on_failure=[spy, async_spy]
+                    until=AttemptsExhausted(3), on_failure=[spy, async_hook_wrapper]
                 ):
                     with attempt:
                         attempts += 1
@@ -237,8 +249,14 @@ class TestAttemptingHooks:
             attempts = 0
             spy = MagicMock()
             async_spy = AsyncMock()
+
+            async def async_hook_wrapper(state: AttemptState) -> None:
+                await async_spy(state=state)
+
             for attempt in attempting(
-                until=AttemptsExhausted(3), wait=1, before_wait=[spy, async_spy]
+                until=AttemptsExhausted(3),
+                wait=1,
+                before_wait=[spy, async_hook_wrapper],
             ):
                 with attempt:
                     attempts += 1
@@ -262,8 +280,12 @@ class TestAttemptingHooks:
             attempts = 0
             spy = MagicMock()
             async_spy = AsyncMock()
+
+            async def async_hook_wrapper(state: AttemptState) -> None:
+                await async_spy(state=state)
+
             for attempt in attempting(
-                until=AttemptsExhausted(3), wait=1, after_wait=[spy, async_spy]
+                until=AttemptsExhausted(3), wait=1, after_wait=[spy, async_hook_wrapper]
             ):
                 with attempt:
                     attempts += 1
@@ -289,7 +311,7 @@ class TestAttemptingHooks:
             def failing_hook(state: AttemptState | None):
                 raise Exception("Test exception")
 
-            async def async_failing_hook(state: AttemptState | None):
+            async def async_failing_hook(state: AttemptState) -> None:
                 raise Exception("Test exception")
 
             attempts = 0
@@ -326,8 +348,12 @@ class TestAttemptingHooks:
 
             attempts = 0
             async_spy = AsyncMock()
+
+            async def async_hook_wrapper(state: AttemptState) -> None:
+                await async_spy(state=state)
+
             for attempt in attempting(
-                until=AttemptsExhausted(3), before_attempt=[async_spy]
+                until=AttemptsExhausted(3), before_attempt=[async_hook_wrapper]
             ):
                 with attempt:
                     attempts += 1
@@ -347,8 +373,13 @@ class TestAttemptingHooks:
             attempts = 0
             sync_spy = MagicMock()
             async_spy = AsyncMock()
+
+            async def async_hook_wrapper(state: AttemptState) -> None:
+                await async_spy(state=state)
+
             async for attempt in attempting_async(
-                until=AttemptsExhausted(3), before_attempt=[sync_spy, async_spy]
+                until=AttemptsExhausted(3),
+                before_attempt=[sync_spy, async_hook_wrapper],
             ):
                 async with attempt:
                     attempts += 1
@@ -373,8 +404,12 @@ class TestAttemptingHooks:
             attempts = 0
             sync_spy = MagicMock()
             async_spy = AsyncMock()
+
+            async def async_hook_wrapper(state: AttemptState) -> None:
+                await async_spy(state=state)
+
             async for attempt in attempting_async(
-                until=AttemptsExhausted(3), on_success=[sync_spy, async_spy]
+                until=AttemptsExhausted(3), on_success=[sync_spy, async_hook_wrapper]
             ):
                 async with attempt:
                     attempts += 1
@@ -393,10 +428,15 @@ class TestAttemptingHooks:
             attempts = 0
             sync_spy = MagicMock()
             async_spy = AsyncMock()
+
+            async def async_hook_wrapper(state: AttemptState) -> None:
+                await async_spy(state=state)
+
             exception = Exception("Test exception")
             with pytest.raises(Exception):
                 async for attempt in attempting_async(
-                    until=AttemptsExhausted(3), on_failure=[sync_spy, async_spy]
+                    until=AttemptsExhausted(3),
+                    on_failure=[sync_spy, async_hook_wrapper],
                 ):
                     async with attempt:
                         attempts += 1
@@ -423,8 +463,14 @@ class TestAttemptingHooks:
             attempts = 0
             sync_spy = MagicMock()
             async_spy = AsyncMock()
+
+            async def async_hook_wrapper(state: AttemptState) -> None:
+                await async_spy(state=state)
+
             async for attempt in attempting_async(
-                until=AttemptsExhausted(3), wait=1, before_wait=[sync_spy, async_spy]
+                until=AttemptsExhausted(3),
+                wait=1,
+                before_wait=[sync_spy, async_hook_wrapper],
             ):
                 async with attempt:
                     attempts += 1
@@ -448,8 +494,14 @@ class TestAttemptingHooks:
             attempts = 0
             sync_spy = MagicMock()
             async_spy = AsyncMock()
+
+            async def async_hook_wrapper(state: AttemptState) -> None:
+                await async_spy(state=state)
+
             async for attempt in attempting_async(
-                until=AttemptsExhausted(3), wait=1, after_wait=[sync_spy, async_spy]
+                until=AttemptsExhausted(3),
+                wait=1,
+                after_wait=[sync_spy, async_hook_wrapper],
             ):
                 async with attempt:
                     attempts += 1

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -296,6 +296,7 @@ class TestHookDecorators:
     class TestSync:
         def test_retry_decorator_with_before_attempt_hook(self):
             spy = MagicMock()
+            async_spy = AsyncMock()
 
             @retry(until=AttemptsExhausted(2))
             def f(x: int) -> int:
@@ -305,11 +306,17 @@ class TestHookDecorators:
             def before_attempt(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
                 spy(state)
 
+            @f.before_attempt
+            async def async_before_attempt(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
+                await async_spy(state)
+
             f(3)
             spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
+            async_spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
 
         def test_retry_decorator_with_on_success_hook(self):
             spy = MagicMock()
+            async_spy = AsyncMock()
 
             @retry(until=AttemptsExhausted(2))
             def f(x: int) -> int:
@@ -319,11 +326,17 @@ class TestHookDecorators:
             def on_success(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
                 spy(state)
 
+            @f.on_success
+            async def async_on_success(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
+                await async_spy(state)
+
             f(3)
             spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
+            async_spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
 
         def test_retry_decorator_with_on_failure_hook(self):
             spy = MagicMock()
+            async_spy = AsyncMock()
             exception = RuntimeError()
 
             @retry(until=AttemptsExhausted(2))
@@ -334,10 +347,20 @@ class TestHookDecorators:
             def on_failure(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
                 spy(state)
 
+            @f.on_failure
+            async def async_on_failure(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
+                await async_spy(state)
+
             with pytest.raises(RuntimeError):
                 f(3)
 
             spy.assert_has_calls(
+                [
+                    call(AttemptState(attempt=1, exception=exception)),
+                    call(AttemptState(attempt=2, exception=exception)),
+                ]
+            )
+            async_spy.assert_has_calls(
                 [
                     call(AttemptState(attempt=1, exception=exception)),
                     call(AttemptState(attempt=2, exception=exception)),
@@ -347,6 +370,7 @@ class TestHookDecorators:
         @pytest.mark.usefixtures("mock_sleep")
         def test_retry_decorator_with_before_wait_hook(self):
             spy = MagicMock()
+            async_spy = AsyncMock()
             exception = RuntimeError()
 
             @retry(until=AttemptsExhausted(2), wait=1)
@@ -357,6 +381,10 @@ class TestHookDecorators:
             def before_wait(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
                 spy(state)
 
+            @f.before_wait
+            async def async_before_wait(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
+                await async_spy(state)
+
             with pytest.raises(RuntimeError):
                 f(3)
 
@@ -365,10 +393,16 @@ class TestHookDecorators:
                     call(AttemptState(attempt=2, exception=None)),
                 ]
             )
+            async_spy.assert_has_calls(
+                [
+                    call(AttemptState(attempt=2, exception=None)),
+                ]
+            )
 
         @pytest.mark.usefixtures("mock_sleep")
         def test_retry_decorator_with_after_wait_hook(self):
             spy = MagicMock()
+            async_spy = AsyncMock()
             exception = RuntimeError()
 
             @retry(until=AttemptsExhausted(2), wait=1)
@@ -379,6 +413,10 @@ class TestHookDecorators:
             def after_wait(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
                 spy(state)
 
+            @f.after_wait
+            async def async_after_wait(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
+                await async_spy(state)
+
             with pytest.raises(RuntimeError):
                 f(3)
 
@@ -387,10 +425,16 @@ class TestHookDecorators:
                     call(AttemptState(attempt=2, exception=None)),
                 ]
             )
+            async_spy.assert_has_calls(
+                [
+                    call(AttemptState(attempt=2, exception=None)),
+                ]
+            )
 
     class TestAsync:
         async def test_retry_decorator_with_before_attempt_hook(self):
             spy = MagicMock()
+            async_spy = AsyncMock()
 
             @retry(until=AttemptsExhausted(2))
             async def f(x: int) -> int:
@@ -400,11 +444,17 @@ class TestHookDecorators:
             def before_attempt(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
                 spy(state)
 
+            @f.before_attempt
+            async def async_before_attempt(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
+                await async_spy(state)
+
             await f(3)
             spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
+            async_spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
 
         async def test_retry_decorator_with_on_success_hook(self):
             spy = MagicMock()
+            async_spy = AsyncMock()
 
             @retry(until=AttemptsExhausted(2))
             async def f(x: int) -> int:
@@ -414,11 +464,17 @@ class TestHookDecorators:
             def on_success(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
                 spy(state)
 
+            @f.on_success
+            async def async_on_success(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
+                await async_spy(state)
+
             await f(3)
             spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
+            async_spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
 
         async def test_retry_decorator_with_on_failure_hook(self):
             spy = MagicMock()
+            async_spy = AsyncMock()
             exception = RuntimeError()
 
             @retry(until=AttemptsExhausted(2))
@@ -429,6 +485,10 @@ class TestHookDecorators:
             def on_failure(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
                 spy(state)
 
+            @f.on_failure
+            async def async_on_failure(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
+                await async_spy(state)
+
             with pytest.raises(RuntimeError):
                 await f(3)
 
@@ -438,10 +498,17 @@ class TestHookDecorators:
                     call(AttemptState(attempt=2, exception=exception)),
                 ]
             )
+            async_spy.assert_has_calls(
+                [
+                    call(AttemptState(attempt=1, exception=exception)),
+                    call(AttemptState(attempt=2, exception=exception)),
+                ]
+            )
 
         @pytest.mark.usefixtures("mock_async_sleep")
         async def test_retry_decorator_with_before_wait_hook(self):
             spy = MagicMock()
+            async_spy = AsyncMock()
             exception = RuntimeError()
 
             @retry(until=AttemptsExhausted(2), wait=1)
@@ -452,6 +519,10 @@ class TestHookDecorators:
             def before_wait(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
                 spy(state)
 
+            @f.before_wait
+            async def async_before_wait(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
+                await async_spy(state)
+
             with pytest.raises(RuntimeError):
                 await f(3)
 
@@ -460,10 +531,16 @@ class TestHookDecorators:
                     call(AttemptState(attempt=2, exception=None)),
                 ]
             )
+            async_spy.assert_has_calls(
+                [
+                    call(AttemptState(attempt=2, exception=None)),
+                ]
+            )
 
         @pytest.mark.usefixtures("mock_async_sleep")
         async def test_retry_decorator_with_after_wait_hook(self):
             spy = MagicMock()
+            async_spy = AsyncMock()
             exception = RuntimeError()
 
             @retry(until=AttemptsExhausted(2), wait=1)
@@ -474,10 +551,19 @@ class TestHookDecorators:
             def after_wait(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
                 spy(state)
 
+            @f.after_wait
+            async def async_after_wait(state: AttemptState):  # pyright: ignore[reportUnusedFunction]
+                await async_spy(state)
+
             with pytest.raises(RuntimeError):
                 await f(3)
 
             spy.assert_has_calls(
+                [
+                    call(AttemptState(attempt=2, exception=None)),
+                ]
+            )
+            async_spy.assert_has_calls(
                 [
                     call(AttemptState(attempt=2, exception=None)),
                 ]


### PR DESCRIPTION
With these changes, attempt lifecycle hooks can be either sync or async regardless of whether the retry decorator is used with a sync or async function.
