### PR TITLE
Add `result` attribute to attempt state

### DIFF
--- a/mule/_attempts/aio.py
+++ b/mule/_attempts/aio.py
@@ -5,7 +5,7 @@ import datetime
 import inspect
 import logging
 from types import TracebackType
-from typing import TYPE_CHECKING, Literal, Sequence, cast
+from typing import TYPE_CHECKING, Any, Literal, Sequence, cast
 
 from mule._attempts.protocols import AsyncAttemptHook, AttemptHook, HookType
 from mule.stop_conditions import NoException, StopCondition
@@ -48,12 +48,14 @@ class AsyncAttemptGenerator:
         else:
             self.stop_condition: "StopCondition" = until | NoException()
         self.wait = wait
-        self._attempts: list[AsyncAttemptContext] = []
         self.before_attempt = before_attempt
         self.on_success = on_success
         self.on_failure = on_failure
         self.before_wait = before_wait
         self.after_wait = after_wait
+
+        self._attempts: list[AsyncAttemptContext] = []
+        self._result: Any | None = None
 
     @property
     def last_attempt(self) -> AsyncAttemptContext | None:
@@ -166,6 +168,7 @@ class AsyncAttemptContext:
     ):
         self.attempt = attempt
         self.exception: BaseException | None = None
+        self.result: Any = ...
         self.before_attempt = before_attempt
         self.on_success = on_success
         self.on_failure = on_failure
@@ -212,6 +215,7 @@ class AsyncAttemptContext:
         return AttemptState(
             attempt=self.attempt,
             exception=self.exception,
+            result=self.result,
         )
 
 

--- a/mule/_attempts/aio.py
+++ b/mule/_attempts/aio.py
@@ -55,7 +55,6 @@ class AsyncAttemptGenerator:
         self.after_wait = after_wait
 
         self._attempts: list[AsyncAttemptContext] = []
-        self._result: Any | None = None
 
     @property
     def last_attempt(self) -> AsyncAttemptContext | None:
@@ -168,7 +167,7 @@ class AsyncAttemptContext:
     ):
         self.attempt = attempt
         self.exception: BaseException | None = None
-        self.result: Any = ...
+        self.result: Any = ...  # Ellipsis is used as a sentinel to indicate that a result has not been set yet.
         self.before_attempt = before_attempt
         self.on_success = on_success
         self.on_failure = on_failure

--- a/mule/_attempts/dataclasses.py
+++ b/mule/_attempts/dataclasses.py
@@ -6,6 +6,16 @@ from typing import Any
 
 @dataclass
 class AttemptState:
+    """
+    A dataclass that represents the state of an attempt.
+
+    Args:
+        attempt: The attempt number.
+        exception: The exception that occurred, if any.
+        result: The result of the attempt, if any. Ellipsis is used as a sentinel
+            to indicate that a result has not been set yet.
+    """
+
     attempt: int
     exception: BaseException | None = None
     result: Any = ...

--- a/mule/_attempts/dataclasses.py
+++ b/mule/_attempts/dataclasses.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
 class AttemptState:
     attempt: int
     exception: BaseException | None = None
+    result: Any = ...

--- a/mule/_attempts/sync.py
+++ b/mule/_attempts/sync.py
@@ -6,7 +6,7 @@ import logging
 import time
 from inspect import iscoroutinefunction
 from types import TracebackType
-from typing import TYPE_CHECKING, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Sequence
 
 from mule._attempts.protocols import HookType
 from mule.stop_conditions import NoException, StopCondition
@@ -168,6 +168,7 @@ class AttemptContext:
     ):
         self.attempt = attempt
         self.exception: BaseException | None = None
+        self.result: Any = ...
         self.before_attempt = before_attempt
         self.on_success = on_success
         self.on_failure = on_failure
@@ -215,6 +216,7 @@ class AttemptContext:
         return AttemptState(
             attempt=self.attempt,
             exception=self.exception,
+            result=self.result,
         )
 
 

--- a/mule/_attempts/sync.py
+++ b/mule/_attempts/sync.py
@@ -168,7 +168,7 @@ class AttemptContext:
     ):
         self.attempt = attempt
         self.exception: BaseException | None = None
-        self.result: Any = ...
+        self.result: Any = ...  # Ellipsis is used as a sentinel to indicate that a result has not been set yet.
         self.before_attempt = before_attempt
         self.on_success = on_success
         self.on_failure = on_failure

--- a/mule/_retry.py
+++ b/mule/_retry.py
@@ -68,7 +68,9 @@ class Retriable(Generic[P, R]):
             after_wait=self.after_wait_hooks,
         ):
             with attempt:
-                return self.fn(*args, **kwargs)
+                result = self.fn(*args, **kwargs)
+                attempt.result = result
+                return result
 
         raise RuntimeError(
             "Failed to make a single attempt with the given stop condition"
@@ -89,7 +91,9 @@ class Retriable(Generic[P, R]):
                     if TYPE_CHECKING:
                         assert iscoroutinefunction(self.fn)  # pragma: no cover
 
-                    return await self.fn(*args, **kwargs)
+                    result = await self.fn(*args, **kwargs)
+                    attempt.result = result
+                    return result
 
             raise RuntimeError(
                 "Failed to make a single attempt with the given stop condition"

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -333,8 +333,12 @@ class TestHookDecorators:
                 await async_spy(state)
 
             f(3)
-            spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
-            async_spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
+            spy.assert_called_once_with(
+                AttemptState(attempt=1, exception=None, result=9)
+            )
+            async_spy.assert_called_once_with(
+                AttemptState(attempt=1, exception=None, result=9)
+            )
 
         def test_retry_decorator_with_on_failure_hook(self):
             spy = MagicMock()
@@ -471,8 +475,12 @@ class TestHookDecorators:
                 await async_spy(state)
 
             await f(3)
-            spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
-            async_spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
+            spy.assert_called_once_with(
+                AttemptState(attempt=1, exception=None, result=9)
+            )
+            async_spy.assert_called_once_with(
+                AttemptState(attempt=1, exception=None, result=9)
+            )
 
         async def test_retry_decorator_with_on_failure_hook(self):
             spy = MagicMock()


### PR DESCRIPTION
Users will be able to access the result in `on_success` hook invocations.
