### PR TITLE
Add `wait_seconds` attribute to `AttemptState`

### DIFF
--- a/mule/_attempts/dataclasses.py
+++ b/mule/_attempts/dataclasses.py
@@ -19,3 +19,4 @@ class AttemptState:
     attempt: int
     exception: BaseException | None = None
     result: Any = ...
+    wait_seconds: float | None = None

--- a/tests/test_attempts.py
+++ b/tests/test_attempts.py
@@ -267,12 +267,12 @@ class TestAttemptingHooks:
             assert attempts == 2
             spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
 
@@ -296,12 +296,12 @@ class TestAttemptingHooks:
             assert attempts == 2
             spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
 
@@ -481,12 +481,12 @@ class TestAttemptingHooks:
             assert attempts == 2
             sync_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
 
@@ -512,12 +512,12 @@ class TestAttemptingHooks:
             assert attempts == 2
             sync_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -396,12 +396,12 @@ class TestHookDecorators:
 
             spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None)),
+                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None)),
+                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
 
@@ -428,12 +428,12 @@ class TestHookDecorators:
 
             spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None)),
+                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None)),
+                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
 
@@ -538,12 +538,12 @@ class TestHookDecorators:
 
             spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None)),
+                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None)),
+                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
 
@@ -570,11 +570,11 @@ class TestHookDecorators:
 
             spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None)),
+                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None)),
+                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
                 ]
             )


### PR DESCRIPTION
These changes will give users access to the wait time between attempts within `before_wait` and `after_wait` hooks.
