### PR TITLE
Add `phase` attribute to track attempt lifecycle state

### DIFF
--- a/mule/_attempts/__init__.py
+++ b/mule/_attempts/__init__.py
@@ -3,6 +3,7 @@ from .aio import (
     AsyncAttemptGenerator,
     attempting_async,
 )
+from .dataclasses import AttemptState, Phase
 from .protocols import WaitTimeProvider
 from .sync import AttemptContext, AttemptGenerator, attempting
 
@@ -10,6 +11,8 @@ __all__ = [
     "attempting",
     "AttemptGenerator",
     "AttemptContext",
+    "AttemptState",
+    "Phase",
     "WaitTimeProvider",
     "attempting_async",
     "AsyncAttemptGenerator",

--- a/mule/_attempts/aio.py
+++ b/mule/_attempts/aio.py
@@ -141,8 +141,9 @@ class AsyncAttemptGenerator:
 
                 await asyncio.sleep(wait_seconds)
 
-                await self._call_hooks(attempt, "after_wait")
                 attempt.wait_seconds = None
+                attempt.phase = Phase.PENDING
+                await self._call_hooks(attempt, "after_wait")
 
     async def __anext__(self) -> AsyncAttemptContext:
         if self.stop_condition.is_met(

--- a/mule/_attempts/dataclasses.py
+++ b/mule/_attempts/dataclasses.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
+
+
+class Phase(Enum):
+    """Enum representing the current phase of an attempt."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    WAITING = "waiting"
+    FAILED = "failed"
+    SUCCEEDED = "succeeded"
 
 
 @dataclass
@@ -15,9 +26,11 @@ class AttemptState:
         result: The result of the attempt, if any. Ellipsis is used as a sentinel
             to indicate that a result has not been set yet.
         wait_seconds: The number of seconds waited after the attempt.
+        phase: The current phase of the attempt.
     """
 
     attempt: int
     exception: BaseException | None = None
     result: Any = ...
     wait_seconds: float | None = None
+    phase: Phase = Phase.PENDING

--- a/mule/_attempts/sync.py
+++ b/mule/_attempts/sync.py
@@ -140,8 +140,9 @@ class AttemptGenerator:
                 attempt.phase = Phase.WAITING
                 self._call_hooks(attempt, "before_wait")
                 time.sleep(wait_seconds)
-                self._call_hooks(attempt, "after_wait")
+                attempt.phase = Phase.PENDING
                 attempt.wait_seconds = None
+                self._call_hooks(attempt, "after_wait")
 
     def __next__(self) -> AttemptContext:
         if self.stop_condition.is_met(

--- a/tests/test_attempts.py
+++ b/tests/test_attempts.py
@@ -7,8 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, call
 import pytest
 
 from mule import attempting, attempting_async
-from mule._attempts import AsyncAttemptGenerator, AttemptGenerator
-from mule._attempts.dataclasses import AttemptState
+from mule._attempts import AsyncAttemptGenerator, AttemptGenerator, AttemptState, Phase
 from mule.stop_conditions import AttemptsExhausted, NoException
 
 
@@ -179,14 +178,30 @@ class TestAttemptingHooks:
             assert attempts == 2
             spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=1, exception=None)),
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=None, phase=Phase.PENDING
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2, exception=None, phase=Phase.PENDING
+                        )
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=1, exception=None)),
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=None, phase=Phase.PENDING
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2, exception=None, phase=Phase.PENDING
+                        )
+                    ),
                 ]
             )
 
@@ -210,9 +225,11 @@ class TestAttemptingHooks:
                         raise Exception("Test exception")
 
             assert attempts == 2
-            spy.assert_called_once_with(state=AttemptState(attempt=2, exception=None))
+            spy.assert_called_once_with(
+                state=AttemptState(attempt=2, exception=None, phase=Phase.SUCCEEDED)
+            )
             async_spy.assert_called_once_with(
-                state=AttemptState(attempt=2, exception=None)
+                state=AttemptState(attempt=2, exception=None, phase=Phase.SUCCEEDED)
             )
 
         def test_on_failure(self):
@@ -235,16 +252,40 @@ class TestAttemptingHooks:
             assert attempts == 3
             spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=1, exception=exception)),
-                    call(state=AttemptState(attempt=2, exception=exception)),
-                    call(state=AttemptState(attempt=3, exception=exception)),
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=3, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=1, exception=exception)),
-                    call(state=AttemptState(attempt=2, exception=exception)),
-                    call(state=AttemptState(attempt=3, exception=exception)),
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=3, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
                 ]
             )
 
@@ -270,12 +311,26 @@ class TestAttemptingHooks:
             assert attempts == 2
             spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
 
@@ -299,12 +354,26 @@ class TestAttemptingHooks:
             assert attempts == 2
             spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
 
@@ -367,8 +436,16 @@ class TestAttemptingHooks:
             assert attempts == 2
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=1, exception=None)),
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=None, phase=Phase.PENDING
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2, exception=None, phase=Phase.PENDING
+                        )
+                    ),
                 ]
             )
 
@@ -393,14 +470,30 @@ class TestAttemptingHooks:
             assert attempts == 2
             sync_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=1, exception=None)),
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=None, phase=Phase.PENDING
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2, exception=None, phase=Phase.PENDING
+                        )
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=1, exception=None)),
-                    call(state=AttemptState(attempt=2, exception=None)),
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=None, phase=Phase.PENDING
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2, exception=None, phase=Phase.PENDING
+                        )
+                    ),
                 ]
             )
 
@@ -425,10 +518,10 @@ class TestAttemptingHooks:
 
             assert attempts == 2
             sync_spy.assert_called_once_with(
-                state=AttemptState(attempt=2, exception=None)
+                state=AttemptState(attempt=2, exception=None, phase=Phase.SUCCEEDED)
             )
             async_spy.assert_called_once_with(
-                state=AttemptState(attempt=2, exception=None)
+                state=AttemptState(attempt=2, exception=None, phase=Phase.SUCCEEDED)
             )
 
         async def test_on_failure(self):
@@ -452,16 +545,40 @@ class TestAttemptingHooks:
             assert attempts == 3
             sync_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=1, exception=exception)),
-                    call(state=AttemptState(attempt=2, exception=exception)),
-                    call(state=AttemptState(attempt=3, exception=exception)),
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=3, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=1, exception=exception)),
-                    call(state=AttemptState(attempt=2, exception=exception)),
-                    call(state=AttemptState(attempt=3, exception=exception)),
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=3, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
                 ]
             )
 
@@ -487,12 +604,26 @@ class TestAttemptingHooks:
             assert attempts == 2
             sync_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
 
@@ -518,12 +649,26 @@ class TestAttemptingHooks:
             assert attempts == 2
             sync_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(state=AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
 

--- a/tests/test_attempts.py
+++ b/tests/test_attempts.py
@@ -358,8 +358,8 @@ class TestAttemptingHooks:
                         state=AttemptState(
                             attempt=2,
                             exception=None,
-                            wait_seconds=1,
-                            phase=Phase.WAITING,
+                            wait_seconds=None,
+                            phase=Phase.PENDING,
                         )
                     ),
                 ]
@@ -370,8 +370,76 @@ class TestAttemptingHooks:
                         state=AttemptState(
                             attempt=2,
                             exception=None,
-                            wait_seconds=1,
+                            wait_seconds=None,
+                            phase=Phase.PENDING,
+                        )
+                    ),
+                ]
+            )
+
+        @pytest.mark.usefixtures("mock_sleep")
+        def test_all_hooks_are_called(self):
+            attempts = 0
+            spy = MagicMock()
+            exception = Exception("Test exception")
+
+            for attempt in attempting(
+                until=AttemptsExhausted(3),
+                wait=1,
+                before_attempt=[spy],
+                on_success=[spy],
+                on_failure=[spy],
+                before_wait=[spy],
+                after_wait=[spy],
+            ):
+                with attempt:
+                    attempts += 1
+                    if attempts < 2:
+                        raise exception
+
+            assert attempts == 2
+            spy.assert_has_calls(
+                [
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=None, phase=Phase.PENDING
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
                             phase=Phase.WAITING,
+                            wait_seconds=1,
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            phase=Phase.PENDING,
+                            wait_seconds=None,
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            phase=Phase.PENDING,
+                            wait_seconds=None,
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            phase=Phase.SUCCEEDED,
+                            wait_seconds=None,
                         )
                     ),
                 ]
@@ -653,8 +721,8 @@ class TestAttemptingHooks:
                         state=AttemptState(
                             attempt=2,
                             exception=None,
-                            wait_seconds=1,
-                            phase=Phase.WAITING,
+                            wait_seconds=None,
+                            phase=Phase.PENDING,
                         )
                     ),
                 ]
@@ -665,8 +733,76 @@ class TestAttemptingHooks:
                         state=AttemptState(
                             attempt=2,
                             exception=None,
-                            wait_seconds=1,
+                            wait_seconds=None,
+                            phase=Phase.PENDING,
+                        )
+                    ),
+                ]
+            )
+
+        @pytest.mark.usefixtures("mock_async_sleep")
+        async def test_all_hooks_are_called(self):
+            attempts = 0
+            spy = AsyncMock()
+            exception = Exception("Test exception")
+
+            async for attempt in attempting_async(
+                until=AttemptsExhausted(3),
+                wait=1,
+                before_attempt=[spy],
+                on_success=[spy],
+                on_failure=[spy],
+                before_wait=[spy],
+                after_wait=[spy],
+            ):
+                async with attempt:
+                    attempts += 1
+                    if attempts < 2:
+                        raise exception
+
+            assert attempts == 2
+            spy.assert_has_calls(
+                [
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=None, phase=Phase.PENDING
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=1, exception=exception, phase=Phase.FAILED
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
                             phase=Phase.WAITING,
+                            wait_seconds=1,
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            phase=Phase.PENDING,
+                            wait_seconds=None,
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            phase=Phase.PENDING,
+                            wait_seconds=None,
+                        )
+                    ),
+                    call(
+                        state=AttemptState(
+                            attempt=2,
+                            exception=None,
+                            phase=Phase.SUCCEEDED,
+                            wait_seconds=None,
                         )
                     ),
                 ]

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -458,8 +458,8 @@ class TestHookDecorators:
                         AttemptState(
                             attempt=2,
                             exception=None,
-                            wait_seconds=1,
-                            phase=Phase.WAITING,
+                            wait_seconds=None,
+                            phase=Phase.PENDING,
                         )
                     ),
                 ]
@@ -470,8 +470,8 @@ class TestHookDecorators:
                         AttemptState(
                             attempt=2,
                             exception=None,
-                            wait_seconds=1,
-                            phase=Phase.WAITING,
+                            wait_seconds=None,
+                            phase=Phase.PENDING,
                         )
                     ),
                 ]
@@ -640,8 +640,8 @@ class TestHookDecorators:
                         AttemptState(
                             attempt=2,
                             exception=None,
-                            wait_seconds=1,
-                            phase=Phase.WAITING,
+                            wait_seconds=None,
+                            phase=Phase.PENDING,
                         )
                     ),
                 ]
@@ -652,8 +652,8 @@ class TestHookDecorators:
                         AttemptState(
                             attempt=2,
                             exception=None,
-                            wait_seconds=1,
-                            phase=Phase.WAITING,
+                            wait_seconds=None,
+                            phase=Phase.PENDING,
                         )
                     ),
                 ]

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
-from mule._attempts.dataclasses import AttemptState
+from mule._attempts.dataclasses import AttemptState, Phase
 from mule._retry import Retriable, retry
 from mule.stop_conditions import AttemptsExhausted, StopCondition
 
@@ -313,8 +313,12 @@ class TestHookDecorators:
                 await async_spy(state)
 
             f(3)
-            spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
-            async_spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
+            spy.assert_called_once_with(
+                AttemptState(attempt=1, exception=None, phase=Phase.PENDING)
+            )
+            async_spy.assert_called_once_with(
+                AttemptState(attempt=1, exception=None, phase=Phase.PENDING)
+            )
 
         def test_retry_decorator_with_on_success_hook(self):
             spy = MagicMock()
@@ -334,10 +338,10 @@ class TestHookDecorators:
 
             f(3)
             spy.assert_called_once_with(
-                AttemptState(attempt=1, exception=None, result=9)
+                AttemptState(attempt=1, exception=None, result=9, phase=Phase.SUCCEEDED)
             )
             async_spy.assert_called_once_with(
-                AttemptState(attempt=1, exception=None, result=9)
+                AttemptState(attempt=1, exception=None, result=9, phase=Phase.SUCCEEDED)
             )
 
         def test_retry_decorator_with_on_failure_hook(self):
@@ -362,14 +366,22 @@ class TestHookDecorators:
 
             spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=1, exception=exception)),
-                    call(AttemptState(attempt=2, exception=exception)),
+                    call(
+                        AttemptState(attempt=1, exception=exception, phase=Phase.FAILED)
+                    ),
+                    call(
+                        AttemptState(attempt=2, exception=exception, phase=Phase.FAILED)
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=1, exception=exception)),
-                    call(AttemptState(attempt=2, exception=exception)),
+                    call(
+                        AttemptState(attempt=1, exception=exception, phase=Phase.FAILED)
+                    ),
+                    call(
+                        AttemptState(attempt=2, exception=exception, phase=Phase.FAILED)
+                    ),
                 ]
             )
 
@@ -396,12 +408,26 @@ class TestHookDecorators:
 
             spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
 
@@ -428,12 +454,26 @@ class TestHookDecorators:
 
             spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
 
@@ -455,8 +495,12 @@ class TestHookDecorators:
                 await async_spy(state)
 
             await f(3)
-            spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
-            async_spy.assert_called_once_with(AttemptState(attempt=1, exception=None))
+            spy.assert_called_once_with(
+                AttemptState(attempt=1, exception=None, phase=Phase.PENDING)
+            )
+            async_spy.assert_called_once_with(
+                AttemptState(attempt=1, exception=None, phase=Phase.PENDING)
+            )
 
         async def test_retry_decorator_with_on_success_hook(self):
             spy = MagicMock()
@@ -476,10 +520,10 @@ class TestHookDecorators:
 
             await f(3)
             spy.assert_called_once_with(
-                AttemptState(attempt=1, exception=None, result=9)
+                AttemptState(attempt=1, exception=None, result=9, phase=Phase.SUCCEEDED)
             )
             async_spy.assert_called_once_with(
-                AttemptState(attempt=1, exception=None, result=9)
+                AttemptState(attempt=1, exception=None, result=9, phase=Phase.SUCCEEDED)
             )
 
         async def test_retry_decorator_with_on_failure_hook(self):
@@ -504,14 +548,22 @@ class TestHookDecorators:
 
             spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=1, exception=exception)),
-                    call(AttemptState(attempt=2, exception=exception)),
+                    call(
+                        AttemptState(attempt=1, exception=exception, phase=Phase.FAILED)
+                    ),
+                    call(
+                        AttemptState(attempt=2, exception=exception, phase=Phase.FAILED)
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=1, exception=exception)),
-                    call(AttemptState(attempt=2, exception=exception)),
+                    call(
+                        AttemptState(attempt=1, exception=exception, phase=Phase.FAILED)
+                    ),
+                    call(
+                        AttemptState(attempt=2, exception=exception, phase=Phase.FAILED)
+                    ),
                 ]
             )
 
@@ -538,12 +590,26 @@ class TestHookDecorators:
 
             spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
 
@@ -570,11 +636,25 @@ class TestHookDecorators:
 
             spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )
             async_spy.assert_has_calls(
                 [
-                    call(AttemptState(attempt=2, exception=None, wait_seconds=1)),
+                    call(
+                        AttemptState(
+                            attempt=2,
+                            exception=None,
+                            wait_seconds=1,
+                            phase=Phase.WAITING,
+                        )
+                    ),
                 ]
             )

--- a/tests/test_stop_conditions.py
+++ b/tests/test_stop_conditions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mule._attempts.dataclasses import AttemptState
+from mule._attempts.dataclasses import AttemptState, Phase
 from mule.stop_conditions import (
     AttemptsExhausted,
     ExceptionMatches,
@@ -24,15 +24,15 @@ class TestAttemptsExhausted:
         stop_condition = AttemptsExhausted(3)
         assert stop_condition.is_met(None) is False
 
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert stop_condition.is_met(context) is False
 
-        context = AttemptState(attempt=2)
+        context = AttemptState(attempt=2, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert stop_condition.is_met(context) is False
 
-        context = AttemptState(attempt=3)
+        context = AttemptState(attempt=3, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert stop_condition.is_met(context) is True
 
@@ -49,7 +49,7 @@ class TestNoException:
         stop_condition = NoException()
         assert stop_condition.is_met(None) is False
 
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert stop_condition.is_met(context) is False
 
@@ -59,22 +59,23 @@ class TestExceptionMatches:
         stop_condition = ExceptionMatches(RuntimeError)
         assert stop_condition.is_met(None) is False
 
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert stop_condition.is_met(context) is True
 
 
 class TestIntersectionStopCondition:
     def test_all_conditions_met(self):
-        context = AttemptState(attempt=3)
+        context = AttemptState(attempt=3, phase=Phase.FAILED)
         context.exception = RuntimeError()
         stop_condition = IntersectionStopCondition(AttemptsExhausted(3), NoException())
         assert stop_condition.is_met(context) is False  # NoException not met
         context.exception = None
+        context.phase = Phase.SUCCEEDED
         assert stop_condition.is_met(context) is True  # Both met
 
     def test_not_all_conditions_met(self):
-        context = AttemptState(attempt=2)
+        context = AttemptState(attempt=2, phase=Phase.FAILED)
         context.exception = RuntimeError()
         stop_condition = IntersectionStopCondition(AttemptsExhausted(3), NoException())
         assert stop_condition.is_met(context) is False
@@ -85,32 +86,32 @@ class TestIntersectionStopCondition:
         assert isinstance(stop_condition, IntersectionStopCondition)
 
         # No exception, but the max attempts is not reached, so it should be false.
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.SUCCEEDED)
         assert stop_condition.is_met(context) is False
 
         # Max attempts is reached, but there is an exception, so it should be false.
-        context = AttemptState(attempt=3)
+        context = AttemptState(attempt=3, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert stop_condition.is_met(context) is False
 
         # No exception and the max attempts is reached, so it should be true.
-        context = AttemptState(attempt=3)
+        context = AttemptState(attempt=3, phase=Phase.SUCCEEDED)
         context.exception = None
         assert stop_condition.is_met(context) is True
 
 
 class TestUnionStopCondition:
     def test_any_condition_met(self):
-        context = AttemptState(attempt=3)
+        context = AttemptState(attempt=3, phase=Phase.FAILED)
         context.exception = RuntimeError()
         stop_condition = UnionStopCondition(AttemptsExhausted(3), NoException())
         assert stop_condition.is_met(context) is True  # AttemptsExhausted met
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.SUCCEEDED)
         context.exception = None
         assert stop_condition.is_met(context) is True  # NoException met
 
     def test_no_conditions_met(self):
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.FAILED)
         context.exception = RuntimeError()
         stop_condition = UnionStopCondition(AttemptsExhausted(3), NoException())
         assert stop_condition.is_met(context) is False
@@ -120,11 +121,11 @@ class TestUnionStopCondition:
         assert isinstance(stop_condition, UnionStopCondition)
 
         # No exception, so it should be true.
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.SUCCEEDED)
         assert stop_condition.is_met(context) is True
 
         # Max attempts is reached, so it should be true.
-        context = AttemptState(attempt=3)
+        context = AttemptState(attempt=3, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert stop_condition.is_met(context) is True
 
@@ -135,22 +136,23 @@ class TestComplexStopConditionCombinations:
         stop_condition = (AttemptsExhausted(3) & NoException()) | ExceptionMatches(
             ValueError
         )
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert (
             stop_condition.is_met(context) is False
         )  # Neither AND nor ExceptionMatches(ValueError) met
 
-        context = AttemptState(attempt=3)
+        context = AttemptState(attempt=3, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert (
             stop_condition.is_met(context) is False
         )  # AND not met, ExceptionMatches(ValueError) not met
 
         context.exception = None
+        context.phase = Phase.SUCCEEDED
         assert stop_condition.is_met(context) is True  # AND met
 
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.FAILED)
         context.exception = ValueError()
         assert (
             stop_condition.is_met(context) is True
@@ -161,7 +163,7 @@ class TestComplexStopConditionCombinations:
         stop_condition = (AttemptsExhausted(3) | NoException()) & ExceptionMatches(
             ValueError
         )
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert (
             stop_condition.is_met(context) is False
@@ -172,7 +174,7 @@ class TestComplexStopConditionCombinations:
             stop_condition.is_met(context) is False
         )  # ExceptionMatches(ValueError) met, NoException not met
 
-        context = AttemptState(attempt=3)
+        context = AttemptState(attempt=3, phase=Phase.FAILED)
         context.exception = ValueError()
         assert (
             stop_condition.is_met(context) is True
@@ -183,11 +185,12 @@ class TestComplexStopConditionCombinations:
         stop_condition = (
             AttemptsExhausted(3) & NoException() & ExceptionMatches(ValueError)
         )
-        context = AttemptState(attempt=3)
+        context = AttemptState(attempt=3, phase=Phase.FAILED)
         context.exception = ValueError()
         assert stop_condition.is_met(context) is False  # NoException not met
 
         context.exception = None
+        context.phase = Phase.SUCCEEDED
         assert (
             stop_condition.is_met(context) is False
         )  # ExceptionMatches(ValueError) not met
@@ -197,19 +200,19 @@ class TestComplexStopConditionCombinations:
         stop_condition = (
             AttemptsExhausted(3) | NoException() | ExceptionMatches(ValueError)
         )
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert stop_condition.is_met(context) is False
 
-        context = AttemptState(attempt=3)
+        context = AttemptState(attempt=3, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert stop_condition.is_met(context) is True  # AttemptsExhausted(3) met
 
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.SUCCEEDED)
         context.exception = None
         assert stop_condition.is_met(context) is True  # NoException met
 
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.FAILED)
         context.exception = ValueError()
         assert (
             stop_condition.is_met(context) is True
@@ -221,11 +224,11 @@ class TestInvertedStopCondition:
         stop_condition = ~ExceptionMatches(RuntimeError)
         assert stop_condition.is_met(None) is False
 
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.FAILED)
         context.exception = RuntimeError()
         assert stop_condition.is_met(context) is False
 
-        context = AttemptState(attempt=1)
+        context = AttemptState(attempt=1, phase=Phase.FAILED)
         context.exception = ValueError()
         assert stop_condition.is_met(context) is True
 


### PR DESCRIPTION
Adds a `phase` attribute to `AttemptState` and `AttemptContext` classes to track the current lifecycle state of retry attempts.

• Added a `Phase` enum with `PENDING`, `RUNNING`, `WAITING`, `FAILED`, and `SUCCEEDED` values
• All attempts start in `PENDING` and transition through phases as they execute
• Phase is set to `RUNNING` after `before_attempt` hooks, `WAITING` during wait periods, and `SUCCEEDED`/`FAILED` based on attempt outcome